### PR TITLE
fix: Fix the length theck for local connections in v1 headers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,13 +791,28 @@ mod tests {
 
     #[test]
     fn test_parse_proxy_header_too_short() {
-        for case in [V1_TCPV4, V1_TCPV6, V2_TCPV4, V2_TCPV6, V1_UNKNOWN].iter() {
-            for i in 0..case.len() - 1 {
+        for case in [
+            V1_TCPV4,
+            V1_TCPV6,
+            V1_UNKNOWN,
+            V2_TCPV4,
+            V2_TCPV6,
+            V2_TCPV4_TLV,
+            V2_LOCAL,
+        ]
+        .iter()
+        {
+            for i in 0..case.len() {
                 assert!(matches!(
                     ProxyHeader::parse(&case[..i], Default::default()),
                     Err(Error::BufferTooShort)
                 ));
             }
+
+            assert!(matches!(
+                ProxyHeader::parse(case, Default::default()),
+                Ok(_)
+            ));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -764,6 +764,8 @@ mod tests {
 
     use super::*;
 
+    const V1_UNKNOWN: &[u8] = b"PROXY UNKNOWN\r\n";
+
     const V1_TCPV4: &[u8] = b"PROXY TCP4 127.0.0.1 192.168.0.1 12345 443\r\n";
     const V1_TCPV6: &[u8] = b"PROXY TCP6 2001:db8::1 ::1 12345 443\r\n";
 
@@ -789,7 +791,7 @@ mod tests {
 
     #[test]
     fn test_parse_proxy_header_too_short() {
-        for case in [V1_TCPV4, V1_TCPV6, V2_TCPV4, V2_TCPV6].iter() {
+        for case in [V1_TCPV4, V1_TCPV6, V2_TCPV4, V2_TCPV6, V1_UNKNOWN].iter() {
             for i in 0..case.len() - 1 {
                 assert!(matches!(
                     ProxyHeader::parse(&case[..i], Default::default()),

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -57,7 +57,8 @@ fn parse_addrs<T: AddressFamily>(buf: &[u8], pos: &mut usize) -> Result<ProxiedA
 fn decode_inner(buf: &[u8]) -> Result<(ProxyHeader, usize), Error> {
     let mut pos = 0;
 
-    if buf.len() < GREETING.len() + 1 + 6 {
+    if buf.len() < b"PROXY UNKNOWN\r\n".len() {
+        // All other valid PROXY headers are longer than this.
         return Err(BufferTooShort);
     }
     if !buf.starts_with(GREETING) {


### PR DESCRIPTION
Fixes #1

Currently parsing `PROXY UNKNOW` returns `Error::Invalid` instead of `Error::BufferTooShort` even though it is a prefix of a valid header `PROXY UNKNOWN\r\n`